### PR TITLE
schema updates, api updates, and improvements using redisvl 0.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     <a href="https://docsearch.redisventures.com"><b>Hosted Demo</b></a>&nbsp;&nbsp;&nbsp;
     <a href="https://github.com/RedisVentures/redis-arXiv-search"><b>Code</b></a>&nbsp;&nbsp;&nbsp;
     <a href="https://datasciencedojo.com/blog/ai-powered-document-search/"><b>Blog Post</b></a>&nbsp;&nbsp;&nbsp;
-    <a href="https://redis.io/docs/stack/search/reference/vectors/"><b>Redis VSS Documentation</b></a>&nbsp;&nbsp;&nbsp;
+    <a href="https://redis.io/docs/interact/search-and-query/advanced-concepts/vectors/"><b>Redis Vector Search Documentation</b></a>&nbsp;&nbsp;&nbsp;
   </div>
     <br />
     <br />
@@ -16,7 +16,7 @@
 # 🔎 Redis arXiv Search
 *This repository is the official codebase for the arxiv paper search app hosted at: **https://docsearch.redisventures.com***
 
-[Redis](https://redis.com) is a highly performant, production-ready vector database, which can be used for many types of applications. Here we showcase Redis vector similarity search (VSS) applied to a document retrieval use case. Read more about AI-powered search in [the technical blog post](https://datasciencedojo.com/blog/ai-powered-document-search/) published by our partners, *[Data Science Dojo](https://datasciencedojo.com)*.
+[Redis](https://redis.com) is a highly performant, production-ready vector database, which can be used for many types of applications. Here we showcase Redis vector search applied to a document retrieval use case. Read more about AI-powered search in [the technical blog post](https://datasciencedojo.com/blog/ai-powered-document-search/) published by our partners, *[Data Science Dojo](https://datasciencedojo.com)*.
 
 ### Dataset
 

--- a/backend/arxivsearch/api/routes.py
+++ b/backend/arxivsearch/api/routes.py
@@ -217,7 +217,7 @@ async def find_papers_by_text(similarity_request: UserTextSimilarityRequest):
         vector=query_vector,
         vector_field_name=paper_vector_field_name,
         num_results=similarity_request.number_of_results,
-        return_fields=config.RETURN_FIELDS
+        return_fields=config.RETURN_FIELDS,
         filter_expression=filter_expression
     )
     # Perform Vector Search

--- a/backend/arxivsearch/api/routes.py
+++ b/backend/arxivsearch/api/routes.py
@@ -1,14 +1,15 @@
 import asyncio
 import numpy as np
 
-from redis.commands.search.query import Query
+from typing import List, Dict, Any, Union
+from fastapi import APIRouter
+
 from redis.commands.search.document import Document
 from redis.commands.search.result import Result
 
 from redisvl.index import AsyncSearchIndex
-from redisvl.query import VectorQuery, FilterQuery
+from redisvl.query import VectorQuery, FilterQuery, CountQuery
 from redisvl.query.filter import Tag, FilterExpression
-from fastapi import APIRouter
 
 from arxivsearch import config
 from arxivsearch.embeddings import Embeddings
@@ -17,7 +18,6 @@ from arxivsearch.schema import (
     UserTextSimilarityRequest
 )
 
-from typing import List, Dict, Any, Union
 
 paper_router = r = APIRouter()
 print("Loading embeddings providers", flush=True)
@@ -35,7 +35,7 @@ def process_paper(paper: Union[Document, Dict[str, Any]]) -> Dict[str, Any]:
     Returns:
         dict: Processed paper data with similarity score.
     """
-    if not isinstance(paper, dict):
+    if isinstance(paper, Document):
         paper = paper.__dict__
     if 'vector_distance' in paper:
         paper['similarity_score'] = 1 - float(paper['vector_distance'])
@@ -47,65 +47,47 @@ def build_filter_expression(years: List[int], categories: List[str]) -> FilterEx
     Construct a filter expression based on the provided years and categories.
 
     Args:
-        years (list): A list of years (integers or strings) to be included in the filter
-                      expression. An empty list means there's no filter applied based on years.
-        categories (list): A list of category strings to be included in the filter
-                           expression. An empty list means there's no filter applied based
-                           on categories.
+        years (list): A list of years (integers or strings) to be included in
+            the filter expression. An empty list means there's no filter applied
+            based on years.
+        categories (list): A list of category strings to be included in the
+            filter expression. An empty list means there's no filter applied
+            based on categories.
 
     Returns:
-        FilterExpression: A FilterExpression object representing the combined filter for both years and categories.
+        FilterExpression: A FilterExpression object representing the combined
+            filter for both years and categories.
     """
-    # Build filters
-    year_filter = Tag("year") == [str(year) for year in years] if years else None
-    category_filter = Tag("categories") == [str(category) for category in categories] if categories else None
-    # Parse and create filter expression
-    if not year_filter and not category_filter:
-        return FilterExpression("*")
-    if year_filter and category_filter:
-        return year_filter & category_filter
-    return year_filter or category_filter
+    year_filter = Tag("year") == [str(year) for year in years if year]
+    category_filter = Tag("categories") == [str(category) for category in categories if category]
+    return year_filter & category_filter
 
 
 def prepare_response(total: int, results: Union[List[Dict[str, Any]], Result]) -> Dict[str, Any]:
     """
     Extract and process papers from search results.
 
-    This function extracts papers from the provided search results, processes each paper,
-    and returns a dictionary containing the total count and a list of processed papers.
+    This function extracts papers from the provided search results, processes
+    each paper, and returns a dictionary containing the total count and a list
+    of processed papers.
 
     Args:
-        total (int): The hypothetical count of papers present in the db that match the filters.
-        results (list): The iterable containing raw paper data.
+        total (int): The hypothetical count of papers present in the db that
+            match the filters.
+        results (Union[List[Dict[str, Any]], Result]): The iterable containing
+            raw paper data.
 
     Returns:
-        dict: A dictionary with 'total' count and a list of 'papers', where each paper is a processed dict.
+        dict: A dictionary with 'total' count and a list of 'papers', where
+            each paper is a processed dict.
     """
     # extract papers from VSS results
-    if not isinstance(results, list):
+    if isinstance(results, Result):
         results = results.docs
     return {
         'total': total,
         'papers': [process_paper(paper) for paper in results]
     }
-
-
-def create_count_query(filter_expression: FilterExpression) -> Query:
-    """
-    Create a "count" query where simply want to know how many records
-    match a particular filter expression
-
-    Args:
-        filter_expression (FilterExpression): The filter expression for the query.
-
-    Returns:
-        Query: The Redis query object.
-    """
-    return (
-        Query(str(filter_expression))
-        .no_content()
-        .dialect(2)
-    )
 
 
 @r.get("/", response_model=Dict)
@@ -118,28 +100,32 @@ async def get_papers(
     """Fetch and return papers with optional filtering by years and categories.
 
     Args:
-        limit (int, optional): Maximum number of papers to return. Defaults to 20.
-        skip (int, optional): Number of papers to skip for pagination. Defaults to 0.
-        years (str, optional): Comma-separated string of years to filter papers. Defaults to "".
-        categories (str, optional): Comma-separated string of categories to filter papers. Defaults to "".
+        limit (int, optional): Maximum number of papers to return.
+            Defaults to 20.
+        skip (int, optional): Number of papers to skip for pagination.
+            Defaults to 0.
+        years (str, optional): Comma-separated string of years to filter papers.
+            Defaults to "".
+        categories (str, optional): Comma-separated string of categories to
+            filter papers. Defaults to "".
 
     Returns:
         dict: Dictionary containing total count and list of papers.
     """
     # Connect to index
-    index_name = config.DEFAULT_PROVIDER
     index = await AsyncSearchIndex.from_existing(
-        name=index_name,
-        url=config.REDIS_URL
+        name=config.DEFAULT_PROVIDER,
+        redis_url=config.REDIS_URL
     )
     # Build query
     filter_expression = build_filter_expression(
-        [year for year in years.split(",") if year],
-        [cat for cat in categories.split(",") if cat]
+        years.split(","),
+        categories.split(",")
     )
     filter_query = FilterQuery(return_fields=[], filter_expression=filter_expression)
     # Execute search
     result_papers = await index.search(
+        # TODO - expose rvl pagination support to query API
         filter_query.query.paging(skip, limit)
     )
     return prepare_response(result_papers.total, result_papers)
@@ -147,25 +133,25 @@ async def get_papers(
 
 @r.post("/vectorsearch/paper", response_model=Dict)
 async def find_papers_by_paper(similarity_request: PaperSimilarityRequest):
-    """Find and return papers similar to a given paper based on vector similarity.
+    """
+    Find and return papers similar to a given paper based on vector
+    similarity.
 
     Args:
-        similarity_request (SimilarityRequest): Similarity request object containing paper_id, provider,
-                                                number_of_results, years, and categories for filtering.
+        similarity_request (SimilarityRequest): Similarity request object
+            containing paper_id, provider, number_of_results, years, and
+            categories for filtering.
 
     Returns:
         dict: Dictionary containing total count and list of similar papers.
     """
     # Connect to index
-    index_name = similarity_request.provider
     index = await AsyncSearchIndex.from_existing(
-        name=index_name,
-        url=config.REDIS_URL
+        name=similarity_request.provider,
+        redis_url=config.REDIS_URL
     )
     # Fetch paper key and the vector from the HASH, cast to numpy array
-    paper_key = index._get_key({"paper_id": similarity_request.paper_id}, "paper_id")
-    # TODO - improve key parsing in redisvl
-    #paper_key = index.key(similarity_request.paper_id)
+    paper_key = index.key(similarity_request.paper_id)
     paper_vector = np.frombuffer(
         await index.client.hget(paper_key, paper_vector_field_name),
         dtype=np.float32
@@ -180,35 +166,37 @@ async def find_papers_by_paper(similarity_request: PaperSimilarityRequest):
         vector=paper_vector,
         vector_field_name=paper_vector_field_name,
         num_results=similarity_request.number_of_results,
-        return_fields=["paper_id", "authors", "categories", "year", "title", "vector_distance"],
+        return_fields=config.RETURN_FIELDS,
         filter_expression=filter_expression
     )
-    count_query = create_count_query(filter_expression)
+    count_query = CountQuery(filter_expression)
     # Execute search
-    count, result_papers = await asyncio.gather(
-        index.search(count_query),
+    total_count, result_papers = await asyncio.gather(
+        index.query(count_query),
         index.query(paper_similarity_query)
     )
     # Get Paper records of those results
-    return prepare_response(count.total, result_papers)
+    return prepare_response(total_count, result_papers)
 
 
 @r.post("/vectorsearch/text", response_model=Dict)
 async def find_papers_by_text(similarity_request: UserTextSimilarityRequest):
-    """Find and return papers similar to user-provided text based on vector similarity.
+    """
+    Find and return papers similar to user-provided text based on
+    vector similarity.
 
     Args:
-        similarity_request (UserTextSimilarityRequest): Similarity request object containing user_text, provider,
-                                                        number_of_results, years, and categories for filtering.
+        similarity_request (UserTextSimilarityRequest): Similarity request
+            object containing user_text, provider, number_of_results, years,
+            and categories for filtering.
 
     Returns:
         dict: Dictionary containing total count and list of similar papers.
     """
     # Attach to index
-    index_name = similarity_request.provider
     index = await AsyncSearchIndex.from_existing(
-        name=index_name,
-        url=config.REDIS_URL
+        name=similarity_request.provider,
+        redis_url=config.REDIS_URL
     )
     # Build filter expression
     filter_expression = build_filter_expression(
@@ -216,23 +204,23 @@ async def find_papers_by_text(similarity_request: UserTextSimilarityRequest):
         similarity_request.categories
     )
     # Check available paper count and create vector from user text
-    count_query = create_count_query(filter_expression)
-    query_vector, count = await asyncio.gather(
+    count_query = CountQuery(filter_expression)
+    query_vector, total_count = await asyncio.gather(
         embeddings.get(
-            provider=index_name,
+            provider=similarity_request.provider,
             text=similarity_request.user_text
         ),
-        index.search(count_query)
+        index.query(count_query)
     )
     # Assemble vector query
     paper_similarity_query = VectorQuery(
         vector=query_vector,
         vector_field_name=paper_vector_field_name,
         num_results=similarity_request.number_of_results,
-        return_fields=["paper_id", "authors", "categories", "year", "title", "vector_distance"],
+        return_fields=config.RETURN_FIELDS
         filter_expression=filter_expression
     )
     # Perform Vector Search
     result_papers = await index.query(paper_similarity_query)
     # Get Paper records of those results
-    return prepare_response(count.total, result_papers)
+    return prepare_response(total_count, result_papers)

--- a/backend/arxivsearch/config.py
+++ b/backend/arxivsearch/config.py
@@ -12,6 +12,14 @@ DEPLOYMENT_ENV = os.environ.get("DEPLOYMENT", "dev")
 DISTANCE_METRIC = os.environ.get("DISTANCE_METRIC", "COSINE")
 WRITE_CONCURRENCY = os.environ.get("WRITE_CONCURRENCY", 150)
 INDEX_TYPE = os.environ.get("VECSIM_INDEX_TYPE", "HNSW")
+RETURN_FIELDS = [
+    "paper_id",
+    "authors",
+    "categories",
+    "year",
+    "title",
+    "vector_distance"
+]
 
 # Redis
 REDIS_HOST = os.environ.get("REDIS_HOST", "redis")

--- a/backend/arxivsearch/load.py
+++ b/backend/arxivsearch/load.py
@@ -44,9 +44,9 @@ async def write_papers(index: AsyncSearchIndex, papers: list):
         paper['categories'] = paper['categories'].replace(",", "|")
         return paper
 
-    # TODO add an optional preprocessor callable to index.load()
     await index.load(
-        data=[preprocess_paper(paper) for paper in papers],
+        data=papers,
+        preprocess=preprocess_paper,
         concurrency=config.WRITE_CONCURRENCY,
         key_field="paper_id"
     )
@@ -55,21 +55,23 @@ async def load_data():
     # Iterate through embedding providers and create an index for each
     for provider in Provider:
         provider = provider.value
-        index = AsyncSearchIndex.from_yaml(
-            os.path.join("./schema", f"{provider}.yaml")
+        yaml_schema_path = os.path.join("./schema", f"{provider}.yaml")
+        index = (
+            AsyncSearchIndex
+            .from_yaml(yaml_schema_path)
+            .connect(config.REDIS_URL)
         )
-        index.connect(config.REDIS_URL)
         # Check if index exists
         if await index.exists():
             print(f"{provider} index already exists")
         else:
-            print(f"Loading arXiv papers -- {provider} index")
+            print(f"Creating {provider} index")
+            await index.create(overwrite=True)
+            print(f"Loading arXiv papers for {provider} index")
             papers = read_paper_df(provider)
             papers = papers.to_dict('records')
             await write_papers(index=index, papers=papers)
             print(f"{provider} vectors loaded")
-            await index.create()
-            print("Search index created")
 
 
 if __name__ == "__main__":

--- a/backend/arxivsearch/schema/cohere.yaml
+++ b/backend/arxivsearch/schema/cohere.yaml
@@ -1,6 +1,8 @@
 index:
   name: cohere
   prefix: cohere:arXiv
+  storage_type: hash
+  key_separator: ':'
 
 fields:
     # define tag fields

--- a/backend/arxivsearch/schema/huggingface.yaml
+++ b/backend/arxivsearch/schema/huggingface.yaml
@@ -1,6 +1,8 @@
 index:
   name: huggingface
   prefix: huggingface:arXiv
+  storage_type: hash
+  key_separator: ':'
 
 fields:
     # define tag fields

--- a/backend/arxivsearch/schema/openai.yaml
+++ b/backend/arxivsearch/schema/openai.yaml
@@ -1,6 +1,8 @@
 index:
   name: openai
   prefix: openai:arXiv
+  storage_type: hash
+  key_separator: ':'
 
 fields:
     # define tag fields

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,7 +4,7 @@ pandas
 ipython
 numpy
 redis>=5.0.0
-redisvl==0.0.4
+redisvl==0.0.5
 cohere
 openai==0.28.1
 sentence-transformers==2.2.2

--- a/backend/setup.cfg
+++ b/backend/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     numpy
     redis>=5.0.0
     cohere
-    openai
-    redisvl==0.0.4
+    openai==0.28.1
+    redisvl==0.0.5
     sentence-transformers==2.2.2
     sentencepiece==0.1.97

--- a/frontend/src/views/Header.tsx
+++ b/frontend/src/views/Header.tsx
@@ -45,15 +45,15 @@ export const Header = (props: Props) => {
               <NavDropdown.Item href="https://github.com/RedisVentures/redis-arXiv-search">Code</NavDropdown.Item>
               <NavDropdown.Item href="https://datasciencedojo.com/blog/ai-powered-document-search/">Blog</NavDropdown.Item>
               <NavDropdown.Item href="https://github.com/RedisVentures/redis-ai-resources">Redis AI Resources List</NavDropdown.Item>
-              <NavDropdown.Item href="https://forms.gle/ANpHTe2Da5CVGHty7" target="_blank">Talk With Us</NavDropdown.Item>
+              <NavDropdown.Item href="https://redis.com/vss-meeting/" target="_blank">Talk With Us</NavDropdown.Item>
               <NavDropdown.Divider />
-              <NavDropdown.Item href="https://redis.io/docs/stack/search/reference/vectors/">
+              <NavDropdown.Item href="https://redis.io/docs/interact/search-and-query/advanced-concepts/vectors/">
                 Vector Search Docs
               </NavDropdown.Item>
             </NavDropdown>
           </Nav>
           <Nav>
-            <Nav.Link className="btn btn-primary m-2" href="https://forms.gle/ANpHTe2Da5CVGHty7" target="_blank">
+            <Nav.Link className="btn btn-primary m-2" href="https://redis.com/vss-meeting/" target="_blank">
               Talk With Us!
             </Nav.Link>
           </Nav>


### PR DESCRIPTION
- Use CountQuery and the natural `.query()` interface instead of `.search()`
- Much simplified tag filter expression builder
- Use the new `preprocess` support on load
- Comment/docstring wrapping to 80 lines
- Schema YAML file updates
- redisvl bump!